### PR TITLE
output deployed authorization model id

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,13 +27,18 @@ jobs:
         run: |
           echo "STORE_ID=$(jq -r '.id' id.json)" >> $GITHUB_ENV
       - name: Deploy using a file
+        id: 'deploy-file'
         uses: ./
         with:
           api-url: http://localhost:8080
           api-token: key1
           store-id: ${{ env.STORE_ID }}
           model-file-path: ./example/model.fga
+      - name: Output the model ID
+        run: |
+          echo "The model ID is ${{ steps.deploy-file.outputs.authorization_model_id }}"
       - name: Deploy using a string
+        id: 'deploy-string'
         uses: ./
         with:
           api-url: http://localhost:8080
@@ -41,3 +46,6 @@ jobs:
           store-id: ${{ env.STORE_ID }}
           format: json
           model: '{\"schema_version\":\"1.1\",\"type_definitions\":\[\{\"type\":\"user\"\},\{\"type\":\"document\",\"relations\":\{\"reader\":\{\"this\":\{\}\},\"writer\":\{\"this\":\{\}\},\"owner\":\{\"this\":\{\}\}\},\"metadata\":\{\"relations\":\{\"reader\":\{\"directly_related_user_types\":\[\{\"type\":\"user\"\}\]\},\"writer\":\{\"directly_related_user_types\":\[\{\"type\":\"user\"\}\]\},\"owner\":\{\"directly_related_user_types\":\[\{\"type\":\"user\"\}\]\}\}\}\}\]\}'
+      - name: Output the model ID
+        run: |
+          echo "The model ID is ${{ steps.deploy-string.outputs.authorization_model_id }}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+
+
+# IntelliJ IDEA
+.idea
+*.iml

--- a/README.md
+++ b/README.md
@@ -6,14 +6,20 @@ This action can be used to deploy your authorization model to an OpenFGA store.
 
 ## Parameter
 
-| Parameter  | Required/Optional  | Description   |
-|----------|--------------|--------------|
-| `api-url` | Required | The URL to your OpenFGA server     |
-| `api-token` | Required | The token used to when preshared keys are used to authenticate the OpenFGA server     |
-| `store-id` | Required | The store to which the model should be deployed     |
-| `model-file-path` | Optional | The path to your model file relative to the root of your project     |
-| `model` | Optional | The model value if file is not used, Ensure it is character escaped.     |
-| `format` | Optional | Authorization model input format. Can be "fga" or "json", defaults to auto-detecting from the file extension |
+| Parameter         | Required/Optional | Description                                                                                                  |
+|-------------------|-------------------|--------------------------------------------------------------------------------------------------------------|
+| `api-url`         | Required          | The URL to your OpenFGA server                                                                               |
+| `api-token`       | Required          | The token used to when preshared keys are used to authenticate the OpenFGA server                            |
+| `store-id`        | Required          | The store to which the model should be deployed                                                              |
+| `model-file-path` | Optional          | The path to your model file relative to the root of your project                                             |
+| `model`           | Optional          | The model value if file is not used, Ensure it is character escaped.                                         |
+| `format`          | Optional          | Authorization model input format. Can be "fga" or "json", defaults to auto-detecting from the file extension |
+
+## Outputs
+
+| Output                   | Description                                |
+|--------------------------|--------------------------------------------|
+| `authorization_model_id` | The ID of the deployed Authorization Model |
 
 ## Example
 

--- a/action.yml
+++ b/action.yml
@@ -20,8 +20,14 @@ inputs:
     description: The model to be imported into. The characters should be escaped. The value from here will be used if model-file-path is empty
     required: false
   format:
-    description: Authorization model input format. Can be "fga" or "json", defaults to auto-detecting from the file extension 
+    description: Authorization model input format. Can be "fga" or "json", defaults to auto-detecting from the file extension
     required: false
+
+outputs:
+  authorization_model_id:
+    description: The ID of the deployed Authorization Model
+    value: ${{ steps.deploy.outputs.authorization_model_id }}
+
 
 runs:
   using: composite
@@ -31,17 +37,21 @@ runs:
       with:
         repo: openfga/cli
         cache: enable
-    - name: Deploy the file
-      if: ${{ inputs.model-file-path != '' }}
+    - name: Install JQ
+      uses: dcarbone/install-jq-action@v2
+    - name: Deploy
+      id: 'deploy'
       shell: bash
       run: |
-        fga_output=$(fga model write --api-url=${{ inputs.api-url }} --api-token=${{ inputs.api-token }} --store-id=${{ inputs.store-id }} --file=${{ inputs.model-file-path }})
-        echo $fga_output
-        echo "authorization_model_id=${{ fromJson($fga_output).authorization_model_id }}" >> "$GITHUB_OUTPUT"
-    - name: Deploy the command line input
-      if: ${{ inputs.model-file-path == '' }}
-      shell: bash
-      run: |
-        fga_output=$(fga model write --api-url=${{ inputs.api-url }} --api-token=${{ inputs.api-token }} --store-id=${{ inputs.store-id }} --format=${{ inputs.format }} ${{ inputs.model }})
-        echo $fga_output
-        echo "authorization_model_id=${{ fromJson($fga_output).authorization_model_id }}" >> "$GITHUB_OUTPUT"
+        if [ "${{ inputs.model-file-path }}" ]
+        then
+          fga_output=$(fga model write --api-url=${{ inputs.api-url }} --api-token=${{ inputs.api-token }} --store-id=${{ inputs.store-id }} --file=${{ inputs.model-file-path }})
+        else
+          fga_output=$(fga model write --api-url=${{ inputs.api-url }} --api-token=${{ inputs.api-token }} --store-id=${{ inputs.store-id }} --format=${{ inputs.format }} ${{ inputs.model }})
+        fi
+        echo "$fga_output"
+        
+        authorization_model_id=$(echo "$fga_output" | jq -r '.authorization_model_id')
+        echo "authorization_model_id=${authorization_model_id}"
+        echo "authorization_model_id=${authorization_model_id}" >> "$GITHUB_OUTPUT"
+        echo "fga_deploy_output=$fga_output" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Hello there,

The deployed authorization model id is not defined as an action output. Here is a proposal to do so.

## Description

I merged the two deploy steps (from file/string) in order to have a single step id to be able to expose it as an output for the action.
I used jq as the previously used fromJson function was not working.
I added two step in the deploy workflow to test it


## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
