### PR TITLE
chore(ci): restrict deploy workflow permissions to only read contents

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,6 @@
 name: Deploy Action
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/action-openfga-deploy/security/code-scanning/1](https://github.com/openfga/action-openfga-deploy/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow file. This can be done at the top level (applies to all jobs) or at the job level (applies only to the specific job). Since there is only one job in this workflow, either approach is valid, but adding it at the top level is more concise and future-proof. The minimal required permission for most workflows that only need to check out code is `contents: read`. This should be added immediately after the `name:` field and before the `on:` field in `.github/workflows/deploy.yml`.

**Steps:**
- Edit `.github/workflows/deploy.yml`.
- Insert the following block after the `name: Deploy Action` line:
  ```yaml
  permissions:
    contents: read
  ```
- No additional imports, methods, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
